### PR TITLE
Fix lint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ from subprocess import call, check_call
 
 from setuptools import Command, setup
 from setuptools.command.develop import develop
-# from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
 if 'bdist_wheel' in sys.argv:
@@ -75,7 +74,8 @@ class TestCoverage(SimpleCommand):
 
     def run(self):
         """Run unittest quietly and display coverage report."""
-        cmd = 'coverage3 run --source=. setup.py test && coverage3 report'
+        cmd = 'coverage3 run -m unittest discover -qs napps/kytos' \
+              ' && coverage3 report'
         call(cmd, shell=True)
 
 
@@ -87,8 +87,7 @@ class Linter(SimpleCommand):
     def run(self):
         """Run yala."""
         print('Yala is running. It may take several seconds...')
-        check_call('yala *.py',
-                   shell=True)
+        check_call('yala *.py', shell=True)
 
 
 class CITest(SimpleCommand):
@@ -128,22 +127,6 @@ class InstallMode(install):
         print(self.description)
 
 
-# class EggInfo(egg_info):
-#     """Prepare files to be packed."""
-#
-#     def run(self):
-#         """Build css."""
-#         self._install_deps_wheels()
-#         super().run()
-#
-#     @staticmethod
-#     def _install_deps_wheels():
-#         """Python wheels are much faster (no compiling)."""
-#         print('Installing dependencies...')
-#         check_call([sys.executable, '-m', 'pip', 'install', '-r',
-#                     'requirements/run.in'])
-
-
 class DevelopMode(develop):
     """Recommended setup for kytos-napps developers.
 
@@ -151,7 +134,7 @@ class DevelopMode(develop):
     created on the system aiming the current source code.
     """
 
-    description = 'install NApps in development mode'
+    description = 'Install NApps in development mode'
 
     def run(self):
         """Install the package in a developer mode."""
@@ -179,13 +162,6 @@ class DevelopMode(develop):
         (ENABLED_PATH / 'kytos').mkdir(parents=True, exist_ok=True)
         dst = ENABLED_PATH / Path('kytos', 'of_stats')
         symlink_if_different(dst, src)
-
-    # @staticmethod
-    # def _create_file_symlinks():
-    #     """Symlink to required files."""
-    #     src = ENABLED_PATH / '__init__.py'
-    #     dst = CURRENT_DIR / 'napps' / '__init__.py'
-    #     symlink_if_different(src, dst)
 
 
 def symlink_if_different(path, target):
@@ -221,11 +197,9 @@ setup(name=NAPP_NAME,
           'clean': Cleaner,
           'ci': CITest,
           'coverage': TestCoverage,
-
           'develop': DevelopMode,
           'install': InstallMode,
           'lint': Linter,
-          # 'egg_info': EggInfo,
       },
       zip_safe=False,
       classifiers=[

--- a/stats_api.py
+++ b/stats_api.py
@@ -148,7 +148,7 @@ class PortStatsAPI(StatsAPI):
 
     @staticmethod
     def get_random_port_stats():
-        """Generate a random port stats."""
+        """Generate random port stats."""
         stats = {'data': {
             'timestamps': list(range(1508532494, 1508533094, 10)),
             'rx_bytes': [randint(100_000, 1_000_000) for _ in range(30)],
@@ -170,7 +170,7 @@ class PortStatsAPI(StatsAPI):
             row['name'] = iface.name
             row['mac'] = iface.address
             row['speed'] = self._get_speed(iface)
-            yield self._add_utilization(row, iface)
+            yield self._add_utilization(row)
 
     def get_stats(self):
         """See :meth:`get_port_stats`."""
@@ -196,7 +196,7 @@ class PortStatsAPI(StatsAPI):
             iface.set_custom_speed(user_speed)
         return iface.speed
 
-    def _add_utilization(self, row, iface):  # pylint: disable=unused-argument
+    def _add_utilization(self, row):
         """Calculate utilization and also add port number."""
         speed = row['speed']
         if speed is None:

--- a/tests/test_rrd.py
+++ b/tests/test_rrd.py
@@ -23,8 +23,8 @@ class TestRRD(unittest.TestCase):
         Test if the average is 1 at 1234567810 (second).
         """
         # Mock will return a temporary file for rrd file.
-        f, rrd_file = mkstemp('.rrd')
-        os.close(f)
+        file, rrd_file = mkstemp('.rrd')
+        os.close(file)
         get_rrd_method.return_value = rrd_file
 
         start = 1234567800 - STATS_INTERVAL  # can't update using start time
@@ -33,10 +33,10 @@ class TestRRD(unittest.TestCase):
 
         def update_rrd(multiplier):
             """Update rrd."""
-            rx = tx = multiplier * STATS_INTERVAL
-            tstamp = start + rx
+            rx_value = tx_value = multiplier * STATS_INTERVAL
+            tstamp = start + rx_value
             # any value for index is OK
-            rrd.update([None], tstamp, rx=rx, tx=tx)
+            rrd.update([None], tstamp, rx=rx_value, tx=tx_value)
 
         update_rrd(1)
         update_rrd(3)
@@ -51,9 +51,10 @@ class TestRRD(unittest.TestCase):
         self.assertEqual((1.0, 1.0), rows[0])
 
     @patch('napps.kytos.of_stats.stats.Path')
-    def test_non_existent_rrd(self, path_mock):
+    def test_non_existent_rrd(self):
         """Test fetch_latest with non existent rrd."""
-        obj = path_mock.return_value.exists.return_value = False
+        # obj = path_mock.return_value.exists.return_value = False
+        # was not being used
         rrd = RRD('app_folder', ['data_source'])
         row = rrd.fetch_latest('index')
         self.assertEqual(row, {})


### PR DESCRIPTION
Some errors I couldn't solve, and I two of the errors presents are caused by isort and pylint conflict:

setup.py|104:0|Too few public methods (1/2) (R0903, too-few-public-methods) [pylint]
	stats.py|None:None|Imports are incorrectly sorted. [isort] ### the conflict that I was talinkg about
	stats.py|10:0|No name 'MultipartType' in module 'pyof.v0x01.controller2switch.common' (E0611, no-name-in-module) [pylint]
	stats.py|10:0|No name 'v0x01' in module 'pyof.v0x01.controller2switch.common' (E0611, no-name-in-module) [pylint]
	stats.py|15:0|No name 'v0x04' in module 'pyof.v0x04.controller2switch' (E0611, no-name-in-module) [pylint]
	stats.py|274:15|MultipartRequest is not callable (E1102, not-callable) [pylint]
	stats.py|279:4|Parameters differ from overridden 'listen' method (W0221, arguments-differ) [pylint]
	stats.py|324:4|Parameters differ from overridden 'listen' method (W0221, arguments-differ) [pylint]
	stats.py|358:15|MultipartRequest is not callable (E1102, not-callable) [pylint]
	stats.py|363:4|Parameters differ from overridden 'listen' method (W0221, arguments-differ) [pylint]
	stats_api.py|61:52|Instance of 'StatsAPI' has no '_dpid' member (E1101, no-member) [pylint]
	stats_api.py|63:61|Instance of 'StatsAPI' has no '_dpid' member (E1101, no-member) [pylint]
	stats_api.py|78:27|Using possibly undefined loop variable 'col' (W0631, undefined-loop-variable) [pylint]
	stats_api.py|164:4|Parameters differ from overridden '_get_latest_stats' method (W0221, arguments-differ) [pylint]
	stats_api.py|262:4|Parameters differ from overridden '_get_latest_stats' method (W0221, arguments-differ) [pylint]
	tests/test_rrd.py|5:0|Imports from package unittest are not grouped (C0412, ungrouped-imports) [pylint]
	tests/test_user_speed.py|5:0|Imports from package unittest are not grouped (C0412, ungrouped-imports) [pylint] isort conflict
 user_speed.py|7:0|Too few public methods (1/2) (R0903, too-few-public-methods) [pylint]